### PR TITLE
feat: support writeKey()

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,28 @@ The opposite assertion of `expect`.
 
 #### coffee.write(data)
 
-Write data to stdin, see example above.
+Write data to stdin.
+
+```js
+coffee.fork(path.join(fixtures, 'stdin.js'))
+  .write('1\n')
+  .write('2')
+  .expect('stdout', '1\n2')
+  .end();
+```
+
+#### coffee.writeKey(...args)
+
+Write special key sequence to stdin, support `UP` / `DOWN` / `LEFT` / `RIGHT` / `ENTER` / `SPACE`.
+
+All args will join as one key.
+
+```js
+coffee.fork(path.join(fixtures, 'stdin.js'))
+  .writeKey('1', 'ENTER', '2')
+  .expect('stdout', '1\n2')
+  .end();
+```
 
 #### coffee.waitForPrompt(bool)
 
@@ -102,7 +123,8 @@ If you set false, coffee will write stdin immediately, otherwise will wait for `
 coffee.fork('/path/to/cli', [ 'abcdefg' ])
   .waitForPrompt()
   .write('tz\n')
-  .write('2\n');
+  // choose the second item
+  .writeKey('DOWN', 'DOWN', 'ENTER');
   .end(done);
 ```
 

--- a/lib/coffee.js
+++ b/lib/coffee.js
@@ -10,6 +10,15 @@ const show = require('./show');
 const Rule = require('./rule');
 const ErrorRule = require('./rule_error');
 
+const KEYS = {
+  UP: '\u001b[A',
+  DOWN: '\u001b[B',
+  LEFT: '\u001b[D',
+  RIGHT: '\u001b[C',
+  ENTER: '\n',
+  SPACE: ' ',
+};
+
 class Coffee extends EventEmitter {
 
   constructor(opt) {
@@ -164,6 +173,17 @@ class Coffee extends EventEmitter {
     assert(!this._isEndCalled, 'can\'t call write after end');
     this.stdin.push(input);
     return this;
+  }
+
+  /**
+   * Write special key sequence to stdin of the command, if key name not found then write origin key.
+   * @example `.writeKey('2', 'ENTER', '3')`
+   * @param {...String} args - input key names, will join as one key
+   * @return {Coffee} return self for chain
+   */
+  writeKey(...args) {
+    const input = args.map(x => KEYS[x] || x);
+    return this.write(input.join(''));
   }
 
   /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -203,12 +203,22 @@ describe('coffee', () => {
         .end(done);
     });
 
+    it('should receive data from stdin with special key', done => {
+      coffee.fork(path.join(fixtures, 'stdin.js'))
+        .writeKey('1')
+        .writeKey('ENTER')
+        .writeKey('2', 'ENTER', '3')
+        .expect('stdout', '1\n2\n3')
+        .expect('code', 0)
+        .end(done);
+    });
+
     it('should write data when receive message', done => {
       coffee.fork(path.join(fixtures, 'prompt.js'))
         // .debug()
         .waitForPrompt()
         .write('tz\n')
-        .write('2\n')
+        .writeKey('2', 'ENTER')
         .expect('stdout', 'What\'s your name? hi, tz\nHow many coffee do you want? here is your 2 coffee\n')
         .expect('code', 0)
         .end(done);


### PR DESCRIPTION
`coffee.writeKey(...args)`

Write special key sequence to stdin, support `UP` / `DOWN` / `LEFT` / `RIGHT` / `ENTER` / `SPACE`.

All args will join as one key.

```js
coffee.fork('/path/to/cli', [ 'abcdefg' ])
  .waitForPrompt()
  .write('tz\n')
  // choose the second item
  .writeKey('DOWN', 'DOWN', 'ENTER');
  .end(done);
```