### PR TITLE
doc(readme): fix spawn typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ coffee.fork('/path/to/file.js')
 
 see the API chapter below for more details.
 
-### Spwan
+### Spawn
 
 You can also use `spawn` for spawning normal shell scripts.
 


### PR DESCRIPTION
there is a small spelling error of the word spawn in readme.
simply fix it.